### PR TITLE
feat: add VFD Start Date field and enforce date validation before sending invoices

### DIFF
--- a/vfd_providers/utils/utils.py
+++ b/vfd_providers/utils/utils.py
@@ -35,9 +35,25 @@ def generate_tra_vfd(docname, sinv_doc=None, method="POST", caller="Frontend"):
     if not vfd_provider_settings:
         return
 
-    preview = frappe.get_cached_value(vfd_provider_settings, sinv_doc.company, "enable_vfd_preview")
+    settings_info = frappe.get_cached_value(
+        vfd_provider_settings,
+        sinv_doc.company,
+        ["enable_vfd_preview", "vfd_start_date"],
+        as_dict=True
+    )
+
+    if not settings_info.get("vfd_start_date"):
+        frappe.throw(_(f"Please set VFD Start Date in <b>{vfd_provider_settings}</b>"))
     
-    if preview == 1 and caller == "Frontend":
+    if frappe.utils.getdate(sinv_doc.posting_date) < settings_info.get("vfd_start_date"):
+        frappe.throw(
+            _(
+                f"VFD cannot be generated for Invoice before <b>{settings_info.get('vfd_start_date')}</b> \
+                as per the settings in <b>{vfd_provider_settings}</b>"
+            )
+        )
+    
+    if settings_info.get("enable_vfd_preview") == 1 and caller == "Frontend":
         payload = {}
         if vfd_provider.name == "VFDPlus":
             payload = get_vfdplus_payload(sinv_doc)
@@ -94,6 +110,15 @@ def posting_all_vfd_invoices():
         if not vfd_provider_settings:
             continue
 
+        vfd_start_date = frappe.get_cached_value(
+            vfd_provider_settings,
+            company,
+            "vfd_start_date"
+        )
+
+        if not vfd_start_date:
+            continue
+
         invoices = frappe.db.get_all(
             "Sales Invoice",
             filters={
@@ -102,6 +127,7 @@ def posting_all_vfd_invoices():
                 "is_not_vfd_invoice": 0,
                 "is_return": 0,
                 "vfd_status": ["not in", ["Not Sent", "Success"]],
+                "posting_date": [">=", vfd_start_date]
             }
         )
 

--- a/vfd_providers/vfd_providers/doctype/simplify_vfd_settings/simplify_vfd_settings.json
+++ b/vfd_providers/vfd_providers/doctype/simplify_vfd_settings/simplify_vfd_settings.json
@@ -11,10 +11,10 @@
   "details_section",
   "company",
   "username",
-  "column_break_qddy",
   "password",
   "column_break_ffnr",
   "enable_vfd_preview",
+  "vfd_start_date",
   "section_break_rklsa",
   "column_break_pdoy",
   "bearer_token",
@@ -86,10 +86,6 @@
    "label": "Get Token"
   },
   {
-   "fieldname": "column_break_qddy",
-   "fieldtype": "Column Break"
-  },
-  {
    "fieldname": "column_break_ffnr",
    "fieldtype": "Column Break"
   },
@@ -100,11 +96,19 @@
    "fieldtype": "Check",
    "label": "Enable VFD Preview ",
    "search_index": 1
+  },
+  {
+   "description": "A date to start sending invoices to Tax Authority",
+   "fieldname": "vfd_start_date",
+   "fieldtype": "Date",
+   "label": "VFD Start Date",
+   "reqd": 1,
+   "search_index": 1
   }
  ],
  "grid_page_length": 50,
  "links": [],
- "modified": "2025-10-06 17:01:59.097037",
+ "modified": "2026-02-27 16:55:58.472828",
  "modified_by": "Administrator",
  "module": "VFD Providers",
  "name": "Simplify VFD Settings",
@@ -137,6 +141,7 @@
   }
  ],
  "row_format": "Dynamic",
+ "rows_threshold_for_grid_search": 20,
  "sort_field": "modified",
  "sort_order": "DESC",
  "states": [],

--- a/vfd_providers/vfd_providers/doctype/total_vfd_setting/total_vfd_setting.json
+++ b/vfd_providers/vfd_providers/doctype/total_vfd_setting/total_vfd_setting.json
@@ -19,7 +19,8 @@
   "start_date",
   "column_break_nabn",
   "is_vat_grouped",
-  "enable_vfd_preview"
+  "enable_vfd_preview",
+  "vfd_start_date"
  ],
  "fields": [
   {
@@ -93,11 +94,19 @@
    "fieldtype": "Check",
    "label": " Enable VFD Preview",
    "search_index": 1
+  },
+  {
+   "description": "A date to start sending invoices to Tax Authority",
+   "fieldname": "vfd_start_date",
+   "fieldtype": "Date",
+   "label": "VFD Start Date",
+   "reqd": 1,
+   "search_index": 1
   }
  ],
  "grid_page_length": 50,
  "links": [],
- "modified": "2025-10-06 17:35:34.157616",
+ "modified": "2026-02-27 16:57:29.734408",
  "modified_by": "Administrator",
  "module": "VFD Providers",
  "name": "Total VFD Setting",
@@ -130,6 +139,7 @@
   }
  ],
  "row_format": "Dynamic",
+ "rows_threshold_for_grid_search": 20,
  "sort_field": "modified",
  "sort_order": "DESC",
  "states": [],

--- a/vfd_providers/vfd_providers/doctype/vfdplus_settings/vfdplus_settings.json
+++ b/vfd_providers/vfd_providers/doctype/vfdplus_settings/vfdplus_settings.json
@@ -26,9 +26,10 @@
   "street",
   "taxoffice",
   "column_break_mtey",
-  "enable_vfd_preview",
-  "vat_enabled",
   "sandbox",
+  "vat_enabled",
+  "enable_vfd_preview",
+  "vfd_start_date",
   "gc",
   "dev_type",
   "gov_reg_sdate",
@@ -216,11 +217,19 @@
   {
    "fieldname": "section_break_dhfv",
    "fieldtype": "Section Break"
+  },
+  {
+   "description": "A date to start sending invoices to Tax Authority",
+   "fieldname": "vfd_start_date",
+   "fieldtype": "Date",
+   "label": "VFD Start Date",
+   "reqd": 1,
+   "search_index": 1
   }
  ],
  "grid_page_length": 50,
  "links": [],
- "modified": "2025-10-06 17:44:38.855866",
+ "modified": "2026-02-27 16:56:50.760836",
  "modified_by": "Administrator",
  "module": "VFD Providers",
  "name": "VFDPlus Settings",
@@ -253,6 +262,7 @@
   }
  ],
  "row_format": "Dynamic",
+ "rows_threshold_for_grid_search": 20,
  "sort_field": "modified",
  "sort_order": "DESC",
  "states": [],


### PR DESCRIPTION
- Add 'VFD Start Date' (required Date field) to VFDPlus Settings, Simplify VFD Settings, and Total VFD Setting doctypes to control when VFD invoice submission begins

- Validate VFD Start Date is set before generating VFD; throw error if missing

- Prevent VFD generation for invoices with posting_date before the configured VFD Start Date, with a descriptive error message

- Filter scheduled bulk VFD posting to only process invoices on or after the VFD Start Date, and skip companies without a start date

- Refactor settings fetch in generate_tra_vfd to retrieve both enable_vfd_preview and vfd_start_date in a single cached call

- Reorder field layout in VFDPlus Settings (sandbox, vat_enabled, enable_vfd_preview, vfd_start_date) and remove unused column break in Simplify VFD Settings