### PR TITLE
fix: create vfd custom fields on install and migrate

### DIFF
--- a/vfd_providers/hooks.py
+++ b/vfd_providers/hooks.py
@@ -71,6 +71,14 @@ doctype_js = {
 # before_install = "vfd_providers.install.before_install"
 # after_install = "vfd_providers.install.after_install"
 
+after_install = [
+	"vfd_providers.patches.custom_fields.vfd_providers_updated_custom_fields.execute",
+]
+
+after_migrate = [
+	"vfd_providers.patches.custom_fields.vfd_providers_updated_custom_fields.execute",
+]
+
 # Uninstallation
 # ------------
 


### PR DESCRIPTION
Fresh installs mark patches as done without running them, so the vfd fields were never created. Canceling a Sales Invoice then crashed with AttributeError on doc.vfd_rctvnum. Add the field patch to after_install and after_migrate so the fields always exist.