### PR TITLE
fix(vfd): resolve VFD calculation bug for header & item discounts

### DIFF
--- a/vfd_providers/utils/sales_invoice.js
+++ b/vfd_providers/utils/sales_invoice.js
@@ -260,9 +260,9 @@ function show_vfd_preview_dialog(frm, payload, vfd_provider) {
       <thead>
         <tr>
           <th style="text-align:left;">Description</th>
-          <th style="text-align:center; width:60px;">Qty</th>
-          <th style="text-align:right; width:110px;">Unit Amount</th>
-          <th style="text-align:right; width:120px;">Total Amount</th>
+          <th style="text-align:center; width:50px;">Qty</th>
+          <th style="text-align:right; width:140px;">Unit Amount (Incl. VAT)</th>
+          <th style="text-align:right; width:140px;">Total Amount (Incl. VAT)</th>
         </tr>
       </thead>
       <tbody>

--- a/vfd_providers/vfd_providers/utils.py
+++ b/vfd_providers/vfd_providers/utils.py
@@ -4,25 +4,30 @@ from frappe.utils import flt
 def get_vat_amount(item, vat_group, precision=0):
     vat_amount = 0
 
+    # Net amount after item discounts and distributed header discounts
+    net_total = item.base_net_amount if hasattr(item, "base_net_amount") and item.base_net_amount is not None else (item.net_amount if hasattr(item, "net_amount") else item.base_amount)
+
     if str(vat_group) in ["A", "1"]:
         if (
-            (item.base_net_amount + item.get("distributed_discount_amount", 0)) == item.base_amount
+            (net_total + item.get("distributed_discount_amount", 0)) == item.base_amount
         ):
-            # both base amounts are same if the amount is exclusive of VAT
-            amount = item.base_amount * 1.18
+            # Amount is exclusive of VAT: apply 1.18 on final net_total after discounts
+            amount = net_total * 1.18
             if precision > 0:
                 vat_amount = flt(amount, precision)
             else:
                 vat_amount = amount
         else:
+            amount = net_total * 1.18
             if precision > 0:
-                vat_amount = flt(item.base_amount, precision=2)
+                vat_amount = flt(amount, precision=2)
             else:
-                vat_amount = item.base_amount
+                vat_amount = amount
     else:
         if precision > 0:
-            vat_amount = flt(item.base_amount, precision=2)
+            vat_amount = flt(net_total, precision=2)
         else:
-            vat_amount = item.base_amount
-    
+            vat_amount = net_total
+
     return vat_amount
+


### PR DESCRIPTION
- Update get_vat_amount() in utils.py to calculate VAT inclusive prices using base_net_amount instead of base_amount.
- Correctly account for distributed header-level discounts (apply_discount_on) and line-item discounts.
- Update VFD preview dialog table column headers in sales_invoice.js to explicitly state 'Unit Amount (Incl. VAT)' and 'Total Amount (Incl. VAT)'.