### PR TITLE
fix(vfd): resolve VFD payload & preview calculation bug for discounted invoices

### DIFF
--- a/vfd_providers/utils/sales_invoice.js
+++ b/vfd_providers/utils/sales_invoice.js
@@ -167,7 +167,7 @@ function show_vfd_preview_dialog(frm, payload, vfd_provider) {
     const lineTotal = (item.unitAmount || 0) * (item.quantity || 0);
     totalIncl += lineTotal;
     const taxCode = (item.taxType || '').toUpperCase();
-    const taxRate = ["STANDARD", "A"].includes(taxCode) ? 0.18 : 0;
+    const taxRate = ["STANDARD", "A", "1"].includes(taxCode) ? 0.18 : 0;
 
     if (taxRate) {
       const netLineTotal = flt(lineTotal / (1 + taxRate));
@@ -260,9 +260,9 @@ function show_vfd_preview_dialog(frm, payload, vfd_provider) {
       <thead>
         <tr>
           <th style="text-align:left;">Description</th>
-          <th style="text-align:center; width:60px;">Qty</th>
-          <th style="text-align:right; width:110px;">Unit Amount</th>
-          <th style="text-align:right; width:120px;">Total Amount</th>
+          <th style="text-align:center; width:50px;">Qty</th>
+          <th style="text-align:right; width:140px;">Unit Amount (Incl. VAT)</th>
+          <th style="text-align:right; width:140px;">Total Amount (Incl. VAT)</th>
         </tr>
       </thead>
       <tbody>

--- a/vfd_providers/vfd_providers/utils.py
+++ b/vfd_providers/vfd_providers/utils.py
@@ -2,27 +2,21 @@ import frappe
 from frappe.utils import flt
 
 def get_vat_amount(item, vat_group, precision=0):
-    vat_amount = 0
+    """
+    Calculates the VAT-inclusive line item total for TRA VFD payload.
+    Uses base_net_amount (in TZS) to account for all discounts (line & header).
+    """
+    # Net taxable amount in base currency (TZS) after all discounts
+    net_total_tzs = item.get("base_net_amount") if item.get("base_net_amount") is not None else item.base_amount
 
+    # Standard VAT Rate (18% - VAT Group 'A' or '1')
     if str(vat_group) in ["A", "1"]:
-        if (
-            (item.base_net_amount + item.get("distributed_discount_amount", 0)) == item.base_amount
-        ):
-            # both base amounts are same if the amount is exclusive of VAT
-            amount = item.base_amount * 1.18
-            if precision > 0:
-                vat_amount = flt(amount, precision)
-            else:
-                vat_amount = amount
-        else:
-            if precision > 0:
-                vat_amount = flt(item.base_amount, precision=2)
-            else:
-                vat_amount = item.base_amount
+        vat_inclusive_amount = net_total_tzs * 1.18
     else:
-        if precision > 0:
-            vat_amount = flt(item.base_amount, precision=2)
-        else:
-            vat_amount = item.base_amount
-    
-    return vat_amount
+        vat_inclusive_amount = net_total_tzs
+
+    # Format precision if requested
+    if precision > 0:
+        return flt(vat_inclusive_amount, precision)
+    return vat_inclusive_amount
+


### PR DESCRIPTION
- Update get_vat_amount() in utils.py to calculate VAT inclusive prices using base_net_amount instead of base_amount.
- Accurately account for both line-item discounts and distributed header discounts across TZS and multi-currency invoices.
- Add TRA VAT code '1' to taxRate matching in sales_invoice.js preview dialog.
- Update preview dialog table headers to explicitly state 'Unit Amount (Incl. VAT)' and 'Total Amount (Incl. VAT)'.